### PR TITLE
Added Templates for Issues and PR's

### DIFF
--- a/github_ISSUE_TEMPLATE_bug_report_Version3.yml
+++ b/github_ISSUE_TEMPLATE_bug_report_Version3.yml
@@ -1,0 +1,114 @@
+name: Bug report
+description: Report a Bug.
+title: "bug: <short description>"
+labels: ["bug"]
+assignees: []
+body:
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Pre-checks
+      options:
+        - label: I searched existing issues and discussions for duplicates.
+          required: true
+        - label: I can reproduce this on the latest version/main branch.
+          required: false
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of what the bug is.
+      placeholder: Describe the problem you’re seeing.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: If you can provide steps to reproduce the behavior.
+      placeholder: |
+        1. Go to '...'
+        2. Click on '...'
+        3. Scroll to '...'
+        4. See error
+    validations:
+      required: false
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen?
+    validations:
+      required: false
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What actually happened?
+    validations:
+      required: true
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      options:
+        - High
+        - Medium
+        - Low
+    validations:
+      required: true
+
+  - type: input
+    id: browser
+    attributes:
+      label: Browser
+      placeholder: Chrome 129, Firefox 130, Safari 18, Edge 129
+
+  - type: input
+    id: os
+    attributes:
+      label: Operating system
+      placeholder: Windows 11, macOS 14, Ubuntu 22.04, iOS 18, Android 15
+
+  - type: input
+    id: device
+    attributes:
+      label: Device
+      placeholder: Desktop, iPhone 15, Pixel 8, etc.
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected area
+      multiple: true
+      options:
+        - UI
+        - JavaScript logic
+        - Build
+        - Documentation
+        - Other
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Console logs / stack traces
+      description: Paste any relevant logs.
+      render: shell
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots
+      description: If applicable, add screenshots to help explain your problem.
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Add any other context about the problem here.

--- a/github_ISSUE_TEMPLATE_config_Version3.yml
+++ b/github_ISSUE_TEMPLATE_config_Version3.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/github_ISSUE_TEMPLATE_feature_request_Version3.yml
+++ b/github_ISSUE_TEMPLATE_feature_request_Version3.yml
@@ -1,0 +1,84 @@
+name: Feature request
+description: Suggest an idea or improvement.
+title: "feat: <short description>"
+labels: ["enhancement"]
+assignees: []
+body:
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Pre-checks
+      options:
+        - label: I searched existing issues and discussions for a related request.
+          required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem to solve
+      description: What problem does this feature solve?
+      placeholder: Describe the user problem or pain point.
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: How would you like this to work?
+      placeholder: Describe the feature or behavior you'd like to see.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: What alternative solutions have you considered?
+      placeholder: List any alternative approaches.
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      multiple: true
+      options:
+        - UI
+        - JavaScript logic
+        - Build
+        - Documentation
+        - Other
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      options:
+        - Low
+        - Medium
+        - High
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: Define clear criteria for completion.
+      placeholder: |
+        - [ ] Criterion 1
+        - [ ] Criterion 2
+        - [ ] Criterion 3
+
+  - type: textarea
+    id: impact
+    attributes:
+      label: Breaking changes / risks
+      description: Could this break existing behavior? Any risks?
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context / mockups
+      description: Add any extra details, links, or sketches.

--- a/github_pull_request_template_Version3.md
+++ b/github_pull_request_template_Version3.md
@@ -1,0 +1,30 @@
+## Summary
+Explain the context of this change.
+
+## Related issues
+Closes #<issue-number>
+
+## Type of change
+- [ ] Bug fix (non-breaking change)
+- [ ] New feature (non-breaking change)
+- [ ] Breaking change
+- [ ] Refactor
+- [ ] Documentation
+- [ ] CI/CD or build
+
+## Screenshots or UI changes
+If applicable, add before/after screenshots or a short clip.
+
+## Has this been tested?
+Was it tested:
+- [ ] Manual (browsers: Chrome, Firefox, Safari, Edge)
+
+
+## Checklist
+- [ ] I ran the app locally and verified the change
+- [ ] I verified no console errors/regressions in supported browsers
+- [ ] I updated documentation (if applicable)
+- [ ] I followed the code style and rules
+
+## Additional notes
+Anything else reviewers should know.


### PR DESCRIPTION
This pull request introduces a new set of standardized templates for GitHub issues and pull requests, aiming to improve the quality and consistency of user reports and contributions. The main changes include the addition of detailed templates for bug reports, feature requests, and pull requests, as well as configuration to enable blank issues.

**New issue and PR templates:**

_Bug report process improvements:_
* Added a comprehensive bug report template (`github_ISSUE_TEMPLATE_bug_report_Version3.yml`) that collects detailed information including reproduction steps, expected and actual behavior, severity, environment details, affected areas, logs, screenshots, and additional context.

_Feature request process improvements:_
* Added a feature request template (`github_ISSUE_TEMPLATE_feature_request_Version3.yml`) to guide users through describing the problem, proposed solution, alternatives, affected areas, priority, acceptance criteria, risks, and extra context.

_Pull request process improvements:_
* Added a pull request template (`github_pull_request_template_Version3.md`) that prompts contributors to summarize changes, link related issues, specify the type of change, provide screenshots, describe testing, and complete a checklist for quality assurance.

_Configuration:_
* Enabled blank issues via `github_ISSUE_TEMPLATE_config_Version3.yml` to allow submissions without a template if needed.