### PR TITLE
Remove unnecessary closing brace from map.js

### DIFF
--- a/Code/javaScriptFiles/map.js
+++ b/Code/javaScriptFiles/map.js
@@ -196,4 +196,3 @@ export class Map {
         this.ctx.stroke();
     }
 }
-}


### PR DESCRIPTION
## Summary
Explain the context of this change.

## Related issues
Closes #<issue-number>

## Type of change
- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [ ] Build

## Screenshots or UI changes
If applicable, add before/after screenshots or a short clip.

## Has this been tested?
Was it tested:
- [ ] Manual (browsers: Chrome, Firefox, Safari, Edge)


## Checklist
- [ ] I ran the app locally and verified the change
- [ ] I verified no console errors/regressions in supported browsers
- [ ] I updated documentation (if applicable)
- [x] I followed the code style and rules

## Additional notes
Anything else reviewers should know.
