### PR TITLE
Fix tile indexing and drawing logic in Map class

### DIFF
--- a/Code/javaScriptFiles/map.js
+++ b/Code/javaScriptFiles/map.js
@@ -36,7 +36,10 @@ export class Map {
     findTile(x,y){
         let column = Math.floor(x/this.tilelength)
         let row =  Math.floor(y/this.tilelength)
-        return (this.tileData[column][row])
+        if (row < 0 || row >= this.mapHeightTile || column < 0 || column >= this.mapWidthTile)
+        return { walkable: false, height: 0 };
+    
+        return (this.tileData[row][column])
     }
     checkIfFree(mainEntityKoord, entityX, entityY, moveLengthHoriz, moveLengthVert, mapLengthOrWidth, directionX, directionY){
         let mapLong = mapLengthOrWidth * this.tilelength - this.tilelength
@@ -80,19 +83,18 @@ export class Map {
         return (this.checkIfFree("y", entityX, entityY, 0, moveLength, this.mapHeightTile, 0, this.tilelength))
     }
     loadTileData(){
-        for (let i = 0; i<this.mapHeightTile*this.tilelength;i++){
-            for (let j = 0; j<this.mapWidthTile*this.tilelength;j++){
+        for (let i = 0; i<this.mapHeightTile;i++){
+            this.tileData[i] = []
+            for (let j = 0; j<this.mapWidthTile;j++){
                 let tileSetNr = this.mapDataTiles[0].data[this.getTileNr(i, j) ] -1
                 let tileHeight = 0
                 let walkable = true
-                
                 if (this.mapDataTiles[1].data[this.getTileNr(i, j) ]>0)
                     walkable = false
                 else if (this.mapDataTiles[2].data[this.getTileNr(i, j) ]>0)
                     tileHeight = 1
-                else if (this.mapDataTiles[3].data[this.getTileNr(i, j) ]>0)
+                else if (this.mapDataTiles[3].data[this.getTileNr(i, j ) ]>0)
                     tileHeight = 2
-                this.tileData[i*this.tilelength+j]=[]
                 this.tileData[i][j] = {
                 walkable: walkable,
                 height: tileHeight,
@@ -101,19 +103,20 @@ export class Map {
                 tileMapX: j * this.tilelength,
                 tileMapY: i * this.tilelength
                 }
+                this.tileData[i][j]
             }
         }
     }
 
 
-    isTileOutOfBorder(tileColumnWalker, tileRowWalker) {
+    isTileOutOfBorder(tileRowWalker, tileColumnWalker, ) {
     return (
         tileColumnWalker < 0 || tileColumnWalker >= this.mapWidthTile ||
         tileRowWalker < 0 || tileRowWalker >= this.mapHeightTile
     );
     }
 
-    getTileNr(column, row) {
+    getTileNr(row, column) {
        
         return row * this.mapWidthTile + column /* jedes Tile/Kachel hat eine eigene Nr  nach dem Prinzip   1  2   3   4
                                                                                                             5  6   7   8
@@ -128,16 +131,16 @@ export class Map {
         return this.tilelength - holder;
     }
     
-    drawTile(tileColumnWalker, tileRowWalker, leftBorder, topBorder, i, j) {
+    drawTile(tileRowWalker, tileColumnWalker, leftBorder, topBorder, i, j) {
         
         i = Math.floor(i);      //subPixelRendering, ohne das gibt es weiße Linien auf dem Canvas
         j = Math.floor(j);  
-        if (!(this.isTileOutOfBorder(tileColumnWalker, tileRowWalker))) {                                        
+        if (!(this.isTileOutOfBorder(tileRowWalker, tileColumnWalker))) {   
             let leftOffset = this.tilelength - this.offsetToBorder(leftBorder)      
             let topOffset = (this.tilelength - this.offsetToBorder(topBorder))                                //Wie viel von dem TileSetTile gezeichnet werden muss, falls oben am Bildrand nur die hälft z.B. gezeichnet wurde
             this.ctx.drawImage( this.tilesetImage,                                      //Datei aus der das Tile stammt
-                                this.tileData[tileColumnWalker][tileRowWalker].tileSetX + leftOffset,                                               //X Koordinate im TileSet
-                                this.tileData[tileColumnWalker][tileRowWalker].tileSetY + topOffset,                                               //Y Koordinate im TileSet
+                                this.tileData[tileRowWalker][tileColumnWalker].tileSetX + leftOffset,                                               //X Koordinate im TileSet
+                                this.tileData[tileRowWalker][tileColumnWalker].tileSetY + topOffset,                                               //Y Koordinate im TileSet
                                 this.offsetToBorder(leftBorder),                        //Breite des Ausgeschnittenen Tiles
                                 this.offsetToBorder(topBorder),                         //Höhe des Ausgeschnittenen Tiles
                                 i,                                                      //X Position im Canvas 
@@ -157,21 +160,21 @@ export class Map {
             let tileColumnWalker = tileColumn
         
 
-        this.drawTile(tileColumnWalker, tileRowWalker,  leftBorder, topBorder, 0, 0)                //Zeichnen des obersten Tiles
+        this.drawTile(tileRowWalker, tileColumnWalker,  leftBorder, topBorder, 0, 0)                //Zeichnen des obersten Tiles
 
         for (let i = this.offsetToBorder(leftBorder); i < this.FOV; i += this.tilelength) {         
             tileColumnWalker++
-            this.drawTile(tileColumnWalker, tileRowWalker, 0, topBorder, i, 0)                      //Zeichnen der obersten Reihe
+            this.drawTile(tileRowWalker,tileColumnWalker , 0, topBorder, i, 0)                      //Zeichnen der obersten Reihe
         }
 
         for (let j = this.offsetToBorder(topBorder); j < this.FOV; j += this.tilelength) {
             tileRowWalker++
-            this.tileColumnWalker = tileColumn
-            this.drawTile(tileColumnWalker, tileRowWalker, leftBorder, 0, 0, j)                     //Zeichnen der linken Reihe
+            tileColumnWalker = tileColumn
+            this.drawTile(tileRowWalker, tileColumnWalker , leftBorder, 0, 0, j)                     //Zeichnen der linken Reihe
         
             for (let i = this.offsetToBorder(leftBorder); i < this.FOV; i += this.tilelength) {
                 tileColumnWalker++  
-                this.drawTile(tileColumnWalker, tileRowWalker, 0, 0, i, j)                          //Zeichnen der inneren Tiles
+                this.drawTile(tileRowWalker, tileColumnWalker, 0, 0, i, j)                          //Zeichnen der inneren Tiles
             }
         }   
       this.drawMiniMap(player)


### PR DESCRIPTION
Corrects row/column indexing in tile data access and drawing functions to ensure proper map rendering and tile property lookup. Also updates tile data loading to use correct dimensions and fixes out-of-bounds checks.

## Summary
Fixed bug, row and column now correctly used. 

## Related issues
Closes #126 

## Type of change
- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [ ] Build

## Screenshots or UI changes
before: 
<img width="5120" height="2880" alt="image" src="https://github.com/user-attachments/assets/77f9cb01-c99f-4341-9be1-12a8212484d2" />
After: 
<img width="5120" height="2880" alt="image" src="https://github.com/user-attachments/assets/d944321d-bce3-441f-8a4e-7a60070b051d" />


## Has this been tested?
Was it tested:
- [X] Manual (browsers: Chrome, Firefox, Safari, Edge)


## Checklist
- [X] I ran the app locally and verified the change
- [X] I verified no console errors/regressions in supported browsers
- [ ] I updated documentation (if applicable)
- [X] I followed the code style and rules

## Additional notes
Anything else reviewers should know.
