### PR TITLE
Updated Path in map2.json for right implementation.

### DIFF
--- a/Code/Tiled/map2Jungle.json
+++ b/Code/Tiled/map2Jungle.json
@@ -2167,7 +2167,7 @@
         {
          "columns":8,
          "firstgid":1,
-         "image":"..\/..\/Graphics\/tf_jungle_a5.png",
+         "image":"Graphics/tf_jungle_a5.png",
          "imageheight":512,
          "imagewidth":256,
          "margin":0,
@@ -2180,7 +2180,7 @@
         {
          "columns":16,
          "firstgid":129,
-         "image":"..\/..\/Graphics\/tf_jungle_b.png",
+         "image":"Graphics/tf_jungle_b.png",
          "imageheight":512,
          "imagewidth":512,
          "margin":0,


### PR DESCRIPTION
## Summary
This pull request updates the image paths in the `map2Jungle.json` file to use relative paths that start from the `Graphics` directory instead of including parent directory references. This helps standardize asset referencing and may improve compatibility across different environments.

**Asset path updates:**

* Changed the `image` path for the first tileset from `"../../Graphics/tf_jungle_a5.png"` to `"Graphics/tf_jungle_a5.png"` in `map2Jungle.json`.
* Changed the `image` path for the second tileset from `"../../Graphics/tf_jungle_b.png"` to `"Graphics/tf_jungle_b.png"` in `map2Jungle.json`.

## Related issues
Closes #166 

## Type of change
- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [x] Build

## Screenshots or UI changes
_**Not Applicable**_

## Has this been tested?
Was it tested:
- [x] Manual (browsers: Chrome, Firefox, Safari, Edge)


## Checklist
- [x] I ran the app locally and verified the change
- [x] I verified no console errors/regressions in supported browsers
- [ ] I updated documentation (if applicable)
- [x] I followed the code style and rules

## Additional notes
_**Not Applicable**_
