### PR TITLE
148-feat-xp-system xp-system + alert on lvl up

### DIFF
--- a/Code/javaScriptFiles/enemy.js
+++ b/Code/javaScriptFiles/enemy.js
@@ -170,3 +170,14 @@ export function handleEnemyItemPickups(player) {
         }
     }
 }
+
+export function handleEnemyXpPickups(player) {
+    for (let i = enemyXpDrop.length - 1; i >= 0; i--) {
+        const drop = enemyXpDrop[i]
+
+        if (player.checkCollision(drop, 0, 0)) {
+            player.collectXp(2) // Jeder XP-Drop gibt 2 XP
+            enemyXpDrop.splice(i, 1)  //aufgesammelte XP wird gelöscht
+        }
+    }
+}

--- a/Code/javaScriptFiles/game.js
+++ b/Code/javaScriptFiles/game.js
@@ -6,7 +6,7 @@ import {Map} from "./map.js"
 //import { Obstacles } from "./obstacles.js"
 import {Player} from "./player.js"
 import { Enemy } from "./enemy.js"
-import { drawEnemyItem, drawEnemyXp, handleEnemyItemPickups } from "./enemy.js"
+import { drawEnemyItem, drawEnemyXp, handleEnemyItemPickups, handleEnemyXpPickups} from "./enemy.js"
 //import { Projectile } from "./projectile.js"
 //import { Weapon } from "./weapon.js";
 
@@ -235,6 +235,7 @@ export class game {
         drawEnemyXp(ctx, this.PlayerOne, this.MapOne) 
 
         handleEnemyItemPickups(this.PlayerOne)
+        handleEnemyXpPickups(this.PlayerOne)
     }
 }
 

--- a/Code/javaScriptFiles/player.js
+++ b/Code/javaScriptFiles/player.js
@@ -42,6 +42,8 @@ export class Player extends MovingEntity {
         this.speed += 0.2; // das sind nur beispiele, können wir dann ändern
         this.regeneration += 0.1;
         console.log(`Level Up! Neues Level: ${this.level}`);
+        alert("Level Up! Neues Level: " + this.level);
+        alert("xp bis zum nächsten Level: " + (this.level * 10 - this.xp));
     }
 
     die() {
@@ -53,5 +55,14 @@ export class Player extends MovingEntity {
     collectPickup(item) { //wird von game aufgerufen wenn collision mit item, übergibt logik an itemklasse
         if (!item) return;
         item.apply(this);
+    }
+
+    collectXp(xpAmount) {
+        this.xp += xpAmount;
+        const xpForNextLevel = this.level * 10; // Beispiel: 10 XP pro Level
+        if (this.xp >= xpForNextLevel) {
+            this.xp -= xpForNextLevel; // Überschüssige XP behalten
+            this.lvlUp();
+        }
     }
 }


### PR DESCRIPTION
## Summary
Picking up XP increases the XP variable by 2. A level-up system is implemented where level 1 requires 10 XP, level 2 requires 20 XP, level 3 requires 30 XP, and so on. When the player levels up, two temporary alerts are displayed: one showing the new level and another indicating the amount of XP needed for the next level. The functions for leveling up and increasing XP are located in the Player file, while the collision detection for collecting XP is handled in the Enemy file.

## Related issues
Closes #148 

## Type of change
- [ ] Bug fix (non-breaking change)
- [x] New feature (non-breaking change)
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [ ] Build

## Screenshots or UI changes
<img width="1891" height="975" alt="image" src="https://github.com/user-attachments/assets/b9b22b58-ffe1-425b-a54a-32193eada6fb" />
<img width="1895" height="973" alt="image" src="https://github.com/user-attachments/assets/6860f2d1-6c6e-4a2c-b00a-dcedc0b826e1" />


## Has this been tested?
Was it tested:
- [x] Manual (browsers: Chrome, Firefox, Safari, Edge)


## Checklist
- [x] I ran the app locally and verified the change
- [x] I verified no console errors/regressions in supported browsers
- [ ] I updated documentation (if applicable)
- [x] I followed the code style and rules

## Additional notes
-
