### PR TITLE
Added onDeath to constructor in player.js & changed path in Map1.json.

### DIFF
--- a/Code/Tiled/Map1.json
+++ b/Code/Tiled/Map1.json
@@ -416,7 +416,7 @@
         {
          "columns":10,
          "firstgid":1,
-         "image":"..\/..\/Graphics\/terrain_tiles_v2.png",
+         "image":"Graphics/terrain_tiles_v2.png",
          "imageheight":512,
          "imagewidth":320,
          "margin":0,

--- a/Code/javaScriptFiles/player.js
+++ b/Code/javaScriptFiles/player.js
@@ -4,7 +4,7 @@ import {game} from "./game.js"
 export class Player extends MovingEntity {
     ctx
 
-    constructor(globalEntityX, globalEntityY, hp, png, speed, hitbox, ausrüstung = [], weapons = [], regeneration = 0, ctx) {
+    constructor(globalEntityX, globalEntityY, hp, png, speed, hitbox, ausrüstung = [], weapons = [], regeneration = 0, ctx, onDeath) {
         super(globalEntityX, globalEntityY, hp, png, speed, hitbox)
         this.globalEntityX = globalEntityX
         this.globalEntityY = globalEntityY
@@ -14,7 +14,7 @@ export class Player extends MovingEntity {
         this.ausrüstung = ausrüstung;
         this.weapons = weapons;
         this.regeneration = regeneration;
-        this.ctx = ctx
+        this.ctx = ctx;
         this.hp = hp;
         this.maxHp = hp;
         this.png = png;


### PR DESCRIPTION
## Summary

This pull request introduces a minor update to the asset path in the map configuration and adds a new parameter to the `Player` class constructor to support additional functionality. The most important changes are grouped below:

Game asset configuration:

* Updated the image path in `Map1.json` to use a relative path without parent directory traversal, which helps ensure compatibility and easier asset management.

Player class improvements:

* Added an `onDeath` parameter to the `Player` class constructor in `player.js`, allowing for custom behavior when a player dies.
* Minor formatting fix: added a semicolon after assignment to `this.ctx` in the `Player` class for consistency.

## Related issues
Closes #180

## Type of change
- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [ ] Build

## Screenshots or UI changes
If applicable, add before/after screenshots or a short clip.

## Has this been tested?
Was it tested:
- [ ] Manual (browsers: Chrome, Firefox, Safari, Edge)


## Checklist
- [x] I ran the app locally and verified the change
- [x] I verified no console errors/regressions in supported browsers
- [ ] I updated documentation (if applicable)
- [x] I followed the code style and rules

## Additional notes
Anything else reviewers should know.
