### PR TITLE
BugFix main

### DIFF
--- a/Code/javaScriptFiles/enemy.js
+++ b/Code/javaScriptFiles/enemy.js
@@ -206,7 +206,6 @@ export class Enemy extends MovingEntity {
     render(ctx, MapOne, PlayerOne, enemies, projectiles, performanceNow, positionWithin, gridWidth){
         let position=this.updateGridPlace(MapOne.tilelength, enemies, positionWithin, gridWidth)
         this.chasePlayer(MapOne, PlayerOne, enemies)                   // Gegner läuft auf den Spieler zu
-        MapOne.drawMiniEnemy(this)
         if (this.ranged)  this.weapon.render(ctx, PlayerOne, performanceNow, enemies, MapOne, gridWidth)
         if (PlayerOne.checkCollision(this, 0, 0)) {        // Treffer?
             PlayerOne.takeDmg(15, enemies, positionWithin)

--- a/Code/javaScriptFiles/game.js
+++ b/Code/javaScriptFiles/game.js
@@ -62,14 +62,17 @@ export class game {
         switch (map) {
             case 0:
                 this.mapChoice = './Code/Tiled/map2Jungle.json';
+                this.mapChoicePng = './Code/Tiled/map2Jungle.png';
                 this.start()
                 break;
             case 1:
                 this.mapChoice = './Code/Tiled/Map1.json';
+                this.mapChoicePng = './Code/Tiled/Map1.png';
                 this.start()
                 break;
             default:
                 this.mapChoice = './Code/Tiled/map2Jungle.json';
+                this.mapChoicePng = './Code/Tiled/map2Jungle.png';
                 this.start()
         }
     }
@@ -168,7 +171,7 @@ export class game {
         this.mapData = []
         this.loadMap(this.mapChoice).then(() => {  //andere Map: ./Code/Tiled/Map1.json      ./Code/Tiled/map2Jungle.json
             this.mapData = this.mapData[0];
-            this.MapOne = new Map(this.mapData, canvas.width, canvas.height, ctx)
+            this.MapOne = new Map(this.mapData, this.mapChoicePng, canvas.width, canvas.height, ctx)
             this.PlayerOne = new Player(this.mapData.width * this.mapData.tilewidth / 2, this.mapData.height * this.mapData.tilewidth / 2, this.Health, this.maxHealth, this.XP, null, 5, {
                 width: 16,
                 height: 16

--- a/Code/javaScriptFiles/map.js
+++ b/Code/javaScriptFiles/map.js
@@ -36,12 +36,13 @@ export class Map {
                 this.tilesetDesignImage.onload = () => {
                     this.tilesDesignLoaded = true
                 }
+                this.tilesetDesignImage.src = mapData.tilesets[1].image
             }
             this.loadTileData()
         }
+        console.log(png)
         this.tilesetImage.src = mapData.tilesets[0].image
         this.mapImage.src = png
-        if (mapData.tilesets.length > 1) this.tilesetDesignImage.src = mapData.tilesets[1].image
     }
 
     maxAbs(x, y) {
@@ -197,7 +198,7 @@ export class Map {
     }
 
     drawTile(tileRowWalker, tileColumnWalker, leftBorder, topBorder, i, j) {
-
+        
         i = Math.floor(i);      //subPixelRendering, ohne das gibt es weiße Linien auf dem Canvas
         j = Math.floor(j);
         if (!(this.isTileOutOfBorder(tileRowWalker, tileColumnWalker))) {


### PR DESCRIPTION
Introduces a PNG image path for each map selection in game.js and updates the Map class to accept and use this image. Also removes redundant mini enemy rendering from enemy.js and refines tileset image loading logic in map.js.

## Summary
Wurde anscheind bei der PR #224 nicht gespeichert und daher nicht geändert

## Related issues


## Type of change
- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [ ] Build

## Screenshots or UI changes
If applicable, add before/after screenshots or a short clip.

## Has this been tested?
Was it tested:
- [x] Manual (browsers: Chrome, Firefox, Safari, Edge)


## Checklist
- [x] I ran the app locally and verified the change
- [x] I verified no console errors/regressions in supported browsers
- [ ] I updated documentation (if applicable)
- [x] I followed the code style and rules

## Additional notes
Anything else reviewers should know.
