### PR TITLE
Improve enemy spawn logic to prevent out-of-bounds

### DIFF
--- a/Code/javaScriptFiles/enemy.js
+++ b/Code/javaScriptFiles/enemy.js
@@ -26,7 +26,7 @@ export class Enemy extends MovingEntity {
         }
 
     // Gegner zufällig am Kartenrand spawnen
-    static spawnEnemyOutsideView(enemiesArray, player, canvas, tilewidth, gridWidth) {
+    static spawnEnemyOutsideView(enemiesArray, player, canvas, tilewidth, gridWidth, mapWidth, mapHeight, map) {
         const offset = 80
         const side = Math.floor(Math.random() * 4)
 
@@ -41,6 +41,7 @@ export class Enemy extends MovingEntity {
             case 0: // oben
                 x = left + Math.random() * (right - left)
                 y = top - offset
+
                 break
 
             case 1: // rechts
@@ -58,8 +59,8 @@ export class Enemy extends MovingEntity {
                 y = top + Math.random() * (bottom - top)
                 break
         }
-        if (x<0)x=0
-        if (y<0)y=0 // Können außerhalb der Map spawnen, FIXEN
+        x = Math.max(0, Math.min(x, mapWidth * tilewidth))
+        y = Math.max(0, Math.min(y, mapHeight * tilewidth)) // Können außerhalb der Map spawnen, FIXEN
         // falls x / y > Map spawnen sie da trotzdem
 
         let gridMapTile = {column : Math.floor(x / (gridWidth*tilewidth)), row : Math.floor(y / (gridWidth*tilewidth))}
@@ -72,6 +73,7 @@ export class Enemy extends MovingEntity {
         const xpDrop = 2;   
         const elite = false;
         const ranged = Math.random() < 0.3; // 30% Chance, dass dieser Enemy ein Ranged-Enemy ist
+        if(MovingEntity.spawnCheck(map, x, y, hitbox.width, hitbox.height))
         enemiesArray[gridMapTile.row][gridMapTile.column].within.push(new Enemy(x, y, hp, png, speed, hitbox, level, xpDrop, elite, ranged, gridMapTile));
     }
 

--- a/Code/javaScriptFiles/game.js
+++ b/Code/javaScriptFiles/game.js
@@ -191,7 +191,7 @@ export class game {
             }
             this.renderInterval = setInterval(() => this.render(), 5);
             this.enemySpawnInterval = setInterval(() => {
-                Enemy.spawnEnemyOutsideView(this.enemies, this.PlayerOne, canvas, this.mapData.tilewidth, this.gridWidth)
+                Enemy.spawnEnemyOutsideView(this.enemies, this.PlayerOne, canvas, this.mapData.tilewidth, this.gridWidth, this.mapData.width, this.mapData.height, this.MapOne)
             }, 200)
             this.resetTimer()
             this.startGameTimer()

--- a/Code/javaScriptFiles/movingEntity.js
+++ b/Code/javaScriptFiles/movingEntity.js
@@ -53,6 +53,13 @@ export class MovingEntity extends Entity {
         return true // Überschneidung
     }
 
+    static spawnCheck(map, globalEntityX, globalEntityY, hitboxWidth, hitboxHeight){
+        return (map.findTile(globalEntityX , globalEntityY ).walkable &&
+        map.findTile(globalEntityX , globalEntityY + hitboxHeight).walkable &&
+        map.findTile(globalEntityX + hitboxWidth, globalEntityY ).walkable &&
+        map.findTile(globalEntityX + hitboxWidth, globalEntityY + hitboxHeight).walkable)
+    }
+
     attemptMoveAxis(self, axis, move, enemyArray, map, visited = new Set) {
         if (visited.has(self)) {     //Verhindert das selbe Objekt mehrfach besucht wird
             return {success: false}


### PR DESCRIPTION
Enhanced the enemy spawning function to ensure enemies spawn within map boundaries and only on walkable tiles. Added a spawnCheck method to MovingEntity for validating spawn positions, and updated game.js to pass necessary map parameters.

## Summary
Enemys spawnen nun immer in Bound, aber zt an der Border im Sichtbereich

## Related issues
Closes #212 

## Type of change
- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [ ] Build

## Screenshots or UI changes
If applicable, add before/after screenshots or a short clip.

## Has this been tested?
Was it tested:
- [ ] Manual (browsers: Chrome, Firefox, Safari, Edge)


## Checklist
- [x] I ran the app locally and verified the change
- [x] I verified no console errors/regressions in supported browsers
- [ ] I updated documentation (if applicable)
- [x] I followed the code style and rules

## Additional notes
Momentan wird bei nicht möglichem Spawnen kein Enemy gespawnt. erweiterung siehe #238 