### PR TITLE
Fix enemy spawning when game is paused

### DIFF
--- a/Code/javaScriptFiles/game.js
+++ b/Code/javaScriptFiles/game.js
@@ -206,9 +206,10 @@ export class game {
 
     startEnemySpawning() {
         const spawn = () => {
-            if (this.gamePaused) return;
+            if (!this.gamePaused) {
 
             EnemyFactory.spawnEnemyOutsideView(this.enemies, this.PlayerOne, canvas, this.mapData.tilewidth, this.gridWidth, this.mapData.width, this.mapData.height, this.MapOne, 8 /*Anzahl der Gegner pro Spawn*/)
+            }
             this.enemySpawnInterval = setTimeout(spawn, this.getCurrentSpawnInterval())       // quasi rekursiver Aufruf, nur mit variablem Rekursionsschritt (getCurrentSpawnInterval)  mit sich veränderbaren Intervall
         };
     


### PR DESCRIPTION
Corrected the logic in startEnemySpawning to prevent enemies from spawning while the game is paused by checking if the game is not paused before spawning.

## Summary


## Related issues
Closes #275

## Type of change
- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [ ] Build

## Screenshots or UI changes
If applicable, add before/after screenshots or a short clip.

## Has this been tested?
Was it tested:
- [x] Manual (browsers: Chrome, Firefox, Safari, Edge)


## Checklist
- [x] I ran the app locally and verified the change
- [x] I verified no console errors/regressions in supported browsers
- [ ] I updated documentation (if applicable)
- [x] I followed the code style and rules

## Additional notes
Anything else reviewers should know.
