### PR TITLE
Add Google Code-Wiki link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,5 @@ To run the game, simply open the main HTML file in your web browser.
 ## Contributing
 
 As this is a university project, contributions are not expected. However, feel free to fork the repository and adapt it for your own purposes.
+
+*   Google Code-Wiki: https://codewiki.google/github.com/der-mehlmann/projektseminar_e-business 


### PR DESCRIPTION
Added link to Google Code-Wiki for reference.

## Summary
This pull request makes a minor update to the `README.md` file by adding a link to the project's Google Code-Wiki for additional reference.

## Related issues
Closes #<issue-number>

## Type of change
- [ ] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change
- [ ] Refactor
- [x] Documentation
- [ ] Build

## Screenshots or UI changes
If applicable, add before/after screenshots or a short clip.

## Has this been tested?
Was it tested:
- [ ] Manual (browsers: Chrome, Firefox, Safari, Edge)


## Checklist
- [ ] I ran the app locally and verified the change
- [ ] I verified no console errors/regressions in supported browsers
- [ ] I updated documentation (if applicable)
- [ ] I followed the code style and rules

## Additional notes
No Tests for ReadMe.
